### PR TITLE
Updating Check By Assert and Direct Scene Support

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -50,6 +50,7 @@ jobs:
         test-timeout: "45"
         minimum-pass: "0.7"
         direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
         config-file: "res://.gutconf.json"
         ignore-errors: "true"
     - uses: ./
@@ -59,6 +60,7 @@ jobs:
         test-timeout: "45"
         minimum-pass: "0.7"
         direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
     - uses: ./
       continue-on-error: true
@@ -76,5 +78,6 @@ jobs:
         test-timeout: "45"
         minimum-pass: "0.7"
         direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
         max-fails: "6"

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: "Full path to your GUT config file, e.g. 'res://<path>/<config>.json'."
     required: false
     default: "res://.gutconfig.json"
+  result-output-file:
+    description: "Filename to store and read results in XML"
+    required: false
+    default: "test_results.xml"
 
 runs:
   using: 'docker'
@@ -71,6 +75,7 @@ runs:
   - ${{ inputs.max-fails }}
   - ${{ inputs.ignore-errors }}
   - ${{ inputs.config-file }}
+  - ${{ inputs.result-output-file }}
 
 branding:
   icon: 'chevron-right'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -156,6 +156,8 @@ else
     check_by_test
 fi
 
+rm -f ./xml_output.xml
+
 passrate=".0"
 endmsg=""
 if [ "$TESTS" -eq "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,12 +17,18 @@ ASSERT_CHECK=${10}
 MAX_FAILS=${11}
 IGNORE_ERROR=${12}
 CONFIG_FILE=${13}
+RESULT_OUTPUT_FILE=${14}
 
 GODOT_SERVER_TYPE="headless"
 TESTS=0
 FAILED=0
 CUSTOM_DL_PATH="~/custom_dl_folder"
-RUN_OPTIONS="-s addons/gut/gut_cmdln.gd -gdir=${TEST_DIR} -ginclude_subdirs -gjunit_xml_file=res://xml_output.xml -gexit"
+
+RUN_OPTIONS="-s addons/gut/gut_cmdln.gd"
+RUN_OPTIONS="${RUN_OPTIONS} -gdir=${TEST_DIR}"
+RUN_OPTIONS="${RUN_OPTIONS} -ginclude_subdirs"
+RUN_OPTIONS="${RUN_OPTIONS} -gjunit_xml_file=./${RESULT_OUTPUT_FILE}"
+RUN_OPTIONS="${RUN_OPTIONS} -gexit"
 
 # credit: https://stackoverflow.com/questions/24283097/reusing-output-from-last-command-in-bash
 # capture the output of a command so it can be retrieved with ret
@@ -53,7 +59,7 @@ check_by_test() {
 
             break
         fi
-    done < ./xml_output.xml
+    done < ./${RESULT_OUTPUT_FILE}
 
     echo "XML: Tests Detected: ${TESTS}"
     echo "XML: Failed Tests: ${FAILED}"
@@ -72,7 +78,7 @@ check_by_assert() {
         then
             ((FAILED+=1))
         fi
-    done < ./xml_output.xml
+    done < ./${RESULT_OUTPUT_FILE}
 
     echo "XML: Asserts Detected: ${TESTS}"
     echo "XML: Failed Asserts: ${FAILED}"
@@ -156,7 +162,7 @@ else
     check_by_test
 fi
 
-rm -f ./xml_output.xml
+rm -f ./${RESULT_OUTPUT_FILE}
 
 passrate=".0"
 endmsg=""

--- a/tester/test/alt_mode/tests.tscn
+++ b/tester/test/alt_mode/tests.tscn
@@ -14,3 +14,4 @@ __meta__ = {
 _run_on_load = true
 _include_subdirectories = true
 _directory1 = "res://test/unit"
+_junit_xml_file = "res://direct_scene_xml_output.xml"


### PR DESCRIPTION
# Summary
Using the XML output to check for assert tests now. I also noticed some false-positives for the direct scene implementations so I updated the test scene with an XML output property.

- Added a new parameter to specify the filename of the XML output
- Updated the `direct-scene` scene with an XML filename property. Used the newly defined parameter to define the expected output path from the `direct-scene`.

# Warnings?
I don't know how this is going to interact with config files since I am passing the XML filename through the CLI. does the config file take precedence?

